### PR TITLE
.gitlab-ci.yml: disable regression testing for gmx9999 in stable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ stages:
     - git -C ${CI_PROJECT_NAME} checkout -f ${CI_COMMIT_SHA}
     - mkdir -p build
     - pushd build
-    - cmake .. -DENABLE_TESTING=ON -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DENABLE_REGRESSION_TESTING=ON
+    - cmake .. -DENABLE_TESTING=ON -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DENABLE_REGRESSION_TESTING=${REGRESSION_TESTING:-ON}
       -DMODULE_BUILD=${MODULE_BUILD} ${MODULE_BUILD:+-DCMAKE_INSTALL_PREFIX=/home/votca/votca.install}
     - make -O -k -j${j} -l${j} VERBOSE=1
     - make test CTEST_OUTPUT_ON_FAILURE=1
@@ -229,6 +229,7 @@ Release GCC GMX9999:
     CXX: "g++"
     CMAKE_BUILD_TYPE: "Release"
     DISTRO: "fedora_gmx9999"
+    REGRESSION_TESTING: "OFF"
   extends: .build
 
 Release Clang GMX9999:
@@ -237,6 +238,7 @@ Release Clang GMX9999:
     CXX: "clang++"
     CMAKE_BUILD_TYPE: "Release"
     DISTRO: "fedora_gmx9999"
+    REGRESSION_TESTING: "OFF"
   extends: .build
 
 Release GCC GMX9999D:
@@ -245,6 +247,7 @@ Release GCC GMX9999D:
     CXX: "g++"
     CMAKE_BUILD_TYPE: "Release"
     DISTRO: "fedora_gmx9999_d"
+    REGRESSION_TESTING: "OFF"
   extends: .build
 
 Release Clang GMX9999D:
@@ -253,4 +256,5 @@ Release Clang GMX9999D:
     CXX: "clang++"
     CMAKE_BUILD_TYPE: "Release"
     DISTRO: "fedora_gmx9999_d"
+    REGRESSION_TESTING: "OFF"
   extends: .build


### PR DESCRIPTION
Part of https://github.com/votca/votca/issues/155